### PR TITLE
Display Class Demand On ClassCards

### DIFF
--- a/components/ClassCard/ClassCard.tsx
+++ b/components/ClassCard/ClassCard.tsx
@@ -1,4 +1,13 @@
-import {Box, Button, Card, CardActions, CardContent, Modal, Typography, useMediaQuery, useTheme} from "@mui/material";
+import {
+    Box,
+    Button,
+    Card,
+    CardActions,
+    CardContent,
+    Modal, Tooltip,
+    Typography,
+    useTheme
+} from "@mui/material";
 import React, {useState} from "react";
 import Image from "next/image";
 import {SitClass} from "../../types/sitTypes";
@@ -9,13 +18,17 @@ import {randomElementFromArray} from "../../utils/arrayUtils";
 import AccessTimeIcon from '@mui/icons-material/AccessTime';
 import PersonIcon from '@mui/icons-material/Person';
 import LocationOnIcon from '@mui/icons-material/LocationOn';
+import {ActivityDemand} from "../../types/derivedTypes";
+import ClassDemandMeter from "./ClassDemandMeter";
 
 const ClassCard = (
     {
         _class,
+        activityDemand,
         onSelectedChanged
     }: {
         _class: SitClass,
+        activityDemand: ActivityDemand,
         onSelectedChanged: (selected: boolean) => void
     }
 ) => {
@@ -53,6 +66,9 @@ const ClassCard = (
                 borderLeft: `0.4rem solid ${classColorRGB}`
             }}>
             <CardContent className={"unselectable"} onClick={handleClick} sx={{paddingBottom: 1}}>
+                <Box style={{position: "absolute", right: 15}}>
+                    <ClassDemandMeter demandLevel={activityDemand.demandLevel}/>
+                </Box>
                 <Typography
                     sx={{
                         fontSize: "1.05rem",
@@ -140,6 +156,12 @@ const ClassCard = (
                         <PersonIcon/>
                         <Typography variant="body2" color="text.secondary">
                             {_class.instructors.map((i) => i.name).join(", ")}
+                        </Typography>
+                    </Box>
+                    <Box sx={{display: "flex", paddingTop: 1, gap: 1, alignItems: "center"}}>
+                        <ClassDemandMeter demandLevel={activityDemand.demandLevel} />
+                        <Typography variant="body2" color="text.secondary">
+                            {activityDemand.demandLevel}
                         </Typography>
                     </Box>
                     {_class.image && <Box pt={2}>

--- a/components/ClassCard/ClassDemandMeter.tsx
+++ b/components/ClassCard/ClassDemandMeter.tsx
@@ -1,0 +1,19 @@
+import SpeedIcon from '@mui/icons-material/Speed';
+import QuestionMarkIcon from '@mui/icons-material/QuestionMark';
+import {ClassDemandLevel} from "../../types/derivedTypes";
+
+
+const ClassDemandMeter = ({demandLevel}: {demandLevel: ClassDemandLevel}) => {
+    switch (demandLevel) {
+        case ClassDemandLevel.High:
+            return <SpeedIcon style={{color: "red"}}/>;
+        case ClassDemandLevel.Medium:
+            return <SpeedIcon style={{color: "orange"}}/>;
+        case ClassDemandLevel.Low:
+            return <SpeedIcon style={{color: "green"}}/>;
+        default:
+            return <QuestionMarkIcon/>
+    }
+}
+
+export default ClassDemandMeter;

--- a/components/Schedule.tsx
+++ b/components/Schedule.tsx
@@ -3,13 +3,16 @@ import {Box, Stack, Typography, useTheme} from "@mui/material";
 import ClassCard from "./ClassCard/ClassCard";
 import {SitSchedule} from "../types/sitTypes";
 import {weekdayNameToNumber} from "../utils/timeUtils";
+import {ActivityDemand, ClassDemandLevel} from "../types/derivedTypes";
 
 const Schedule = (
     {
         schedule,
+        activityDemands,
         onSelectedChanged
     }: {
         schedule: SitSchedule,
+        activityDemands: ActivityDemand[],
         onSelectedChanged: (classId: string, selected: boolean) => void
     }
 ) => {
@@ -37,6 +40,10 @@ const Schedule = (
                                     <Box key={_class.id} mb={1}>
                                         <ClassCard
                                             _class={_class}
+                                            activityDemand={activityDemands.find(
+                                                (classDemand) => classDemand.activityId ===  _class.activityId)
+                                                ?? {demandLevel: ClassDemandLevel.Unknown} as ActivityDemand
+                                        }
                                             onSelectedChanged={(s) => onSelectedChanged(_class.id.toString(), s)}
                                         />
                                     </Box>

--- a/lib/demand.ts
+++ b/lib/demand.ts
@@ -1,0 +1,9 @@
+import {SitClass} from "../types/sitTypes";
+import {ClassDemandLevel} from "../types/derivedTypes";
+
+export function determineClassDemandLevel(sitClass: SitClass) {
+    if (!sitClass || sitClass.available === undefined) return ClassDemandLevel.Unknown
+    if (sitClass.available <= 0) return ClassDemandLevel.High
+    if (sitClass.available <= 5) return ClassDemandLevel.Medium
+    return ClassDemandLevel.Low
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,24 +5,27 @@ import Head from "next/head";
 import Schedule from "../components/Schedule";
 import Config from "../components/Config";
 import {SitSchedule} from "../types/sitTypes";
-import {fetchSchedule} from "../lib/iBooking";
+import {fetchActivityDemands, fetchSchedule} from "../lib/iBooking";
+import {ActivityDemand} from "../types/derivedTypes";
 
 // Memoize to avoid redundant schedule re-render on class selection change
 const ScheduleMemo = memo(Schedule);
 
 export async function getStaticProps() {
     const schedule = await fetchSchedule();
+    const activityDemands = await fetchActivityDemands();
     const invalidationTimeInSeconds = 60 * 60;
 
     return {
         props: {
             schedule,
+            activityDemands
         },
         revalidate: invalidationTimeInSeconds
     }
 }
 
-const Index: NextPage<{ schedule: SitSchedule }> = ({schedule}) => {
+const Index: NextPage<{ schedule: SitSchedule, activityDemands: ActivityDemand[] }> = ({schedule, activityDemands}) => {
     const [selectedClassIds, setSelectedClassIds] = useState<string[]>([]);
 
     const classes = useMemo(() => {
@@ -63,7 +66,7 @@ const Index: NextPage<{ schedule: SitSchedule }> = ({schedule}) => {
                     divider={<Divider orientation="vertical" flexItem/>}
                 >
                     <Container maxWidth={false} sx={{height: {xs: '70vh', md: '92vh'}, overflow: 'auto'}}>
-                        <ScheduleMemo schedule={schedule} onSelectedChanged={onSelectedChanged}/>
+                        <ScheduleMemo schedule={schedule} activityDemands={activityDemands} onSelectedChanged={onSelectedChanged}/>
                     </Container>
                     <Container sx={{
                         paddingY: 2,

--- a/types/derivedTypes.ts
+++ b/types/derivedTypes.ts
@@ -1,0 +1,11 @@
+export enum ClassDemandLevel {
+    Unknown = "Denne timen gikk ikke forrige uke, og har derfor ukjent popularitet.",
+    Low = "Denne timen har vanligvis mange ledige plasser.",
+    Medium = "Denne timen har vanligvis noen ledige plasser.",
+    High = "Denne timen har vanligvis venteliste."
+}
+
+export type ActivityDemand = {
+    activityId: string,
+    demandLevel: ClassDemandLevel
+}

--- a/types/sitTypes.ts
+++ b/types/sitTypes.ts
@@ -11,6 +11,8 @@ export type SitScheduleDay = {
 export type SitClass = {
     id: number,
     activityId: string,
+    available: number,
+    capacity: number,
     studio: SitStudio,
     from: string,
     to: string,


### PR DESCRIPTION
Display how much demand there were for the classes in the previous week.
This is shown using a gauge on the ClassCard, with an explanatory text
in the ClassCard modal. 

To determine the popularity, I used the amount of available spots for the same class in the prior week. The demand is defined as:
* High Demand - 0 or less spots
* Medium Demand - 5 or less spots
* Low Demand - more than 5 spots
* Unknown Demand - the class did not go the previous week

This feature can be justified now, since we generate the static site periodically. Therefore, the extra fetch requests costs nothing for the end user. 🤙🏻

## Screenshots 🚀
### Schedule
<img width="1018" alt="Screenshot 2023-02-21 at 12 01 46" src="https://user-images.githubusercontent.com/26925695/220329217-66e12457-f82c-49bf-8829-a37e6cb522ca.png">  

### Low Demand
<img width="616" alt="Screenshot 2023-02-21 at 12 02 13" src="https://user-images.githubusercontent.com/26925695/220329206-b85f5a18-9e7d-4f9f-9b51-3229e2f84fc1.png">  

### Medium Demand
<img width="616" alt="Screenshot 2023-02-21 at 12 02 08" src="https://user-images.githubusercontent.com/26925695/220329210-71adb184-9116-4466-bdc1-b7b60a8e861c.png">  

### High Demand
<img width="616" alt="Screenshot 2023-02-21 at 12 02 02" src="https://user-images.githubusercontent.com/26925695/220329215-2985db8b-3d0f-41ca-a2d2-2c9ebd98120e.png">  

### Unknown Demand
<img width="616" alt="Screenshot 2023-02-21 at 12 02 18" src="https://user-images.githubusercontent.com/26925695/220329191-5a0bf4a6-4646-45de-ae3b-2f699f5beda7.png">