### PR TITLE
Class Info Links

### DIFF
--- a/components/ClassCard/ClassCard.tsx
+++ b/components/ClassCard/ClassCard.tsx
@@ -1,15 +1,5 @@
-import {
-    Box,
-    Button,
-    Card,
-    CardActions,
-    CardContent,
-    Modal, Tooltip,
-    Typography,
-    useTheme
-} from "@mui/material";
+import {Box, Button, Card, CardActions, CardContent, Typography, useTheme} from "@mui/material";
 import React, {useState} from "react";
-import Image from "next/image";
 import {SitClass} from "../../types/sitTypes";
 import {simpleTimeStringFromISO} from "../../utils/timeUtils";
 import {hexWithOpacityToRgb} from "../../utils/colorUtils";
@@ -25,23 +15,21 @@ const ClassCard = (
     {
         _class,
         activityPopularity,
-        onSelectedChanged
+        onSelectedChanged,
+        onInfo,
     }: {
         _class: SitClass,
         activityPopularity: ActivityPopularity,
-        onSelectedChanged: (selected: boolean) => void
+        onSelectedChanged: (selected: boolean) => void,
+        onInfo: () => void
     }
 ) => {
 
     const [selected, setSelected] = useState(false);
-    const [open, setOpen] = useState(false);
 
     const theme = useTheme()
 
     const [selectAnimation, setSelectAnimation] = useState<EnterLeaveAnimation | null>(null);
-
-    const handleOpen = () => setOpen(true);
-    const handleClose = () => setOpen(false);
 
     function handleClick() {
         const newSelected = !selected
@@ -95,7 +83,7 @@ const ClassCard = (
                         bgcolor: `${_class.color}10`
                     }
                 }}
-                        onClick={handleOpen}>Info</Button>
+                        onClick={onInfo}>Info</Button>
             </CardActions>
             <Box sx={{
                 position: "absolute",
@@ -119,60 +107,6 @@ const ClassCard = (
                         zIndex: -1
                     }}/>
             )}
-            <Modal
-                open={open}
-                onClose={handleClose}
-            >
-                <Box sx={{
-                    position: 'absolute',
-                    top: '50%',
-                    left: '50%',
-                    width: "95%",
-                    maxHeight: "80%",
-                    overflowY: "scroll",
-                    maxWidth: 600,
-                    transform: 'translate(-50%, -50%)',
-                    backgroundColor: theme.palette.mode === "dark" ? "#212121" : "white",
-                    borderRadius: "0.25em",
-                    boxShadow: 24,
-                    p: 4,
-                }}>
-                    <Typography variant="h6" component="h2">
-                        {_class.name}
-                    </Typography>
-                    <Box sx={{display: "flex", paddingTop: 1, gap: 1, alignItems: "center"}}>
-                        <AccessTimeIcon/>
-                        <Typography variant="body2" color="text.secondary">
-                            {simpleTimeStringFromISO(_class.from)} - {simpleTimeStringFromISO(_class.to)}
-                        </Typography>
-                    </Box>
-                    <Box sx={{display: "flex", paddingTop: 1, gap: 1, alignItems: "center"}}>
-                        <LocationOnIcon/>
-                        <Typography variant="body2" color="text.secondary">
-                            {_class.studio.name}
-                        </Typography>
-                    </Box>
-                    <Box sx={{display: "flex", paddingTop: 1, gap: 1, alignItems: "center"}}>
-                        <PersonIcon/>
-                        <Typography variant="body2" color="text.secondary">
-                            {_class.instructors.map((i) => i.name).join(", ")}
-                        </Typography>
-                    </Box>
-                    <Box sx={{display: "flex", paddingTop: 1, gap: 1, alignItems: "center"}}>
-                        <ClassPopularityMeter popularity={activityPopularity.popularity} />
-                        <Typography variant="body2" color="text.secondary">
-                            {activityPopularity.popularity}
-                        </Typography>
-                    </Box>
-                    {_class.image && <Box pt={2}>
-                        <Image src={_class.image} alt={_class.name} width={600} height={300}
-                               objectFit={'cover'} style={{borderRadius: "0.25em", padding: 0}}></Image>
-                    </Box>}
-                    <Typography pt={2}>
-                        {_class.description}
-                    </Typography>
-                </Box>
-            </Modal>
         </Card>
     )
 }

--- a/components/Schedule.tsx
+++ b/components/Schedule.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from "react";
+import React, {useEffect, useState} from "react";
 import {Box, Modal, Stack, Typography, useTheme} from "@mui/material";
 import ClassCard from "./ClassCard/ClassCard";
 import {ActivityPopularity, ClassPopularity} from "../types/derivedTypes";
@@ -9,6 +9,7 @@ import LocationOnIcon from "@mui/icons-material/LocationOn";
 import PersonIcon from "@mui/icons-material/Person";
 import Image from "next/image";
 import {hexWithOpacityToRgb} from "../utils/colorUtils";
+import {useRouter} from "next/router";
 import ClassPopularityMeter from "./ClassCard/ClassPopularityMeter";
 
 const Schedule = (
@@ -22,10 +23,23 @@ const Schedule = (
         onSelectedChanged: (classId: string, selected: boolean) => void
     }
 ) => {
+    const router = useRouter()
 
     const theme = useTheme()
 
     const [modalClass, setModalClass] = useState<SitClass | null>(null)
+
+    useEffect(() => {
+        const { activityId } = router.query
+        if (activityId !== undefined) {
+            const linkedClass = schedule.days
+                .flatMap((day) => day.classes)
+                .find((_class) => _class.activityId === Number(activityId))
+            if (linkedClass) {
+                setModalClass(linkedClass);
+            }
+        }
+    }, [router.query, schedule.days])
 
     function colorForClass(_class: SitClass) {
         return `rgb(${hexWithOpacityToRgb(
@@ -34,7 +48,7 @@ const Schedule = (
             theme.palette.mode === "dark" ? 0 : 255
         ).join(",")})`
     }
-    
+
     const lookupActivityPopularity = (_class: SitClass): ActivityPopularity => previousActivities.find(
             (activityPopularity) => activityPopularity.activityId ===  _class.activityId)
         ?? {popularity: ClassPopularity.Unknown} as ActivityPopularity

--- a/components/Schedule.tsx
+++ b/components/Schedule.tsx
@@ -30,11 +30,11 @@ const Schedule = (
     const [modalClass, setModalClass] = useState<SitClass | null>(null)
 
     useEffect(() => {
-        const { activityId } = router.query
-        if (activityId !== undefined) {
+        const { classId } = router.query
+        if (classId !== undefined) {
             const linkedClass = schedule.days
                 .flatMap((day) => day.classes)
-                .find((_class) => _class.activityId === Number(activityId))
+                .find((_class) => _class.id === Number(classId))
             if (linkedClass) {
                 setModalClass(linkedClass);
             }

--- a/components/Schedule.tsx
+++ b/components/Schedule.tsx
@@ -1,9 +1,15 @@
-import React from "react";
-import {Box, Stack, Typography, useTheme} from "@mui/material";
+import React, {useState} from "react";
+import {Box, Modal, Stack, Typography, useTheme} from "@mui/material";
 import ClassCard from "./ClassCard/ClassCard";
-import {SitSchedule} from "../types/sitTypes";
-import {weekdayNameToNumber} from "../utils/timeUtils";
 import {ActivityPopularity, ClassPopularity} from "../types/derivedTypes";
+import {SitClass, SitSchedule} from "../types/sitTypes";
+import {simpleTimeStringFromISO, weekdayNameToNumber} from "../utils/timeUtils";
+import AccessTimeIcon from "@mui/icons-material/AccessTime";
+import LocationOnIcon from "@mui/icons-material/LocationOn";
+import PersonIcon from "@mui/icons-material/Person";
+import Image from "next/image";
+import {hexWithOpacityToRgb} from "../utils/colorUtils";
+import ClassPopularityMeter from "./ClassCard/ClassPopularityMeter";
 
 const Schedule = (
     {
@@ -18,6 +24,20 @@ const Schedule = (
 ) => {
 
     const theme = useTheme()
+
+    const [modalClass, setModalClass] = useState<SitClass | null>(null)
+
+    function colorForClass(_class: SitClass) {
+        return `rgb(${hexWithOpacityToRgb(
+            _class.color,
+            0.6,
+            theme.palette.mode === "dark" ? 0 : 255
+        ).join(",")})`
+    }
+    
+    const lookupActivityPopularity = (_class: SitClass): ActivityPopularity => previousActivities.find(
+            (activityPopularity) => activityPopularity.activityId ===  _class.activityId)
+        ?? {popularity: ClassPopularity.Unknown} as ActivityPopularity
 
     return (
         <Stack direction={"row"}>
@@ -40,11 +60,9 @@ const Schedule = (
                                     <Box key={_class.id} mb={1}>
                                         <ClassCard
                                             _class={_class}
-                                            activityPopularity={previousActivities.find(
-                                                (activityPopularity) => activityPopularity.activityId ===  _class.activityId)
-                                                ?? {popularity: ClassPopularity.Unknown} as ActivityPopularity
-                                        }
+                                            activityPopularity={lookupActivityPopularity(_class)}
                                             onSelectedChanged={(s) => onSelectedChanged(_class.id.toString(), s)}
+                                            onInfo={() => setModalClass(_class)}
                                         />
                                     </Box>
                                 );
@@ -52,6 +70,77 @@ const Schedule = (
                         ) : <p>Ingen gruppetimer</p>}
                     </Box>
                 ))}
+            <Modal
+                open={modalClass != null}
+                onClose={() => setModalClass(null)}
+            >
+                <>
+                    {modalClass && (
+                        <Box sx={{
+                            position: 'absolute',
+                            top: '50%',
+                            left: '50%',
+                            width: "95%",
+                            maxHeight: "80%",
+                            overflowY: "scroll",
+                            maxWidth: 600,
+                            transform: 'translate(-50%, -50%)',
+                            backgroundColor: theme.palette.mode === "dark" ? "#212121" : "white",
+                            borderRadius: "0.25em",
+                            boxShadow: 24,
+                            p: 4,
+                        }}>
+                            <Box sx={{display: "flex", alignItems: "center", gap: 1, paddingBottom: 1}}>
+                                <Box sx={{
+                                    backgroundColor: colorForClass(modalClass),
+                                    borderRadius: "50%",
+                                    height: "1.5rem",
+                                    width: "1.5rem"
+                                }}/>
+                                <Typography variant="h6" component="h2">
+                                    {modalClass.name}
+                                </Typography>
+                            </Box>
+                            <Box sx={{display: "flex", paddingTop: 1, gap: 1, alignItems: "center"}}>
+                                <ClassPopularityMeter popularity={lookupActivityPopularity(modalClass).popularity} />
+                                <Typography variant="body2" color="text.secondary">
+                                    {lookupActivityPopularity(modalClass).popularity}
+                                </Typography>
+                            </Box>
+                            <Box
+                                sx={{display: "flex", paddingTop: 1, gap: 1, alignItems: "center"}}>
+                                <AccessTimeIcon/>
+                                <Typography variant="body2" color="text.secondary">
+                                    {simpleTimeStringFromISO(modalClass.from)} - {simpleTimeStringFromISO(modalClass.to)}
+                                </Typography>
+                            </Box>
+                            <Box
+                                sx={{display: "flex", paddingTop: 1, gap: 1, alignItems: "center"}}>
+                                <LocationOnIcon/>
+                                <Typography variant="body2" color="text.secondary">
+                                    {modalClass.studio.name}
+                                </Typography>
+                            </Box>
+                            <Box
+                                sx={{display: "flex", paddingTop: 1, gap: 1, alignItems: "center"}}>
+                                <PersonIcon/>
+                                <Typography variant="body2" color="text.secondary">
+                                    {modalClass.instructors.map((i) => i.name).join(", ")}
+                                </Typography>
+                            </Box>
+                            {modalClass.image && <Box pt={2}>
+                                <Image src={modalClass.image} alt={modalClass.name} width={600}
+                                       height={300}
+                                       objectFit={'cover'}
+                                       style={{borderRadius: "0.25em", padding: 0}}></Image>
+                            </Box>}
+                            <Typography pt={2}>
+                                {modalClass.description}
+                            </Typography>
+                        </Box>
+                    )}
+                </>
+            </Modal>
         </Stack>
     )
 }


### PR DESCRIPTION
Make it possible to link to the info pages for different classes. The link uses the `id` to determine which class has been linked to, and looks like this:
`http://localhost:3000/?id=123455`

If the link is invalid, it is quietly ignored, and all classes are displayed as normal. In the future it would be cool to display a toast with a little message that the link you entered has invalid data.

This PR also refactored out the class info modal from `ClassCard` to `Schedule`, with the same approach as the `auth` branch. 