### PR TITLE
fix: display all of today's events instead of one week ahead of time

### DIFF
--- a/lib/iBooking.ts
+++ b/lib/iBooking.ts
@@ -42,9 +42,14 @@ async function fetchScheduleWithDayOffset(
 
 export async function fetchSchedule() {
     const token = await fetchPublicToken();
-    // Use two fetches to retrieve schedule for the next 8 days
-    const firstBatch = await fetchScheduleWithDayOffset(token, 0);
-    const secondBatch = await fetchScheduleWithDayOffset(token, 4);
+    // Use two fetches to retrieve schedule for the next 7 days
+    // Use offset -1 to fetch all today's events, not just the ones in the future
+    const firstBatch = await fetchScheduleWithDayOffset(token, -1);
+    const secondBatch = await fetchScheduleWithDayOffset(token, 3);
+
+    // Remove yesterday
+    firstBatch.days.shift();
+
     return { days: [...firstBatch.days, ...secondBatch.days] };
 }
 


### PR DESCRIPTION
With this change, all events for the current date is displayed, even those events that are in the past. This makes it possible to not display next weeks day. For instance, currently if today is Thursday, sit-rezervo will show two entries for Thursday, namely this one, and the next. Now, it only shows this Thursday. 

This removes duplication of events in the calendar, and makes it easier to understand (at least in my head)

Before
<img width="1248" alt="Screenshot 2023-05-18 at 16 46 49" src="https://github.com/mathiazom/sit-rezervo-confgen/assets/26925695/8f438740-8f6f-4789-938f-aebf51f20419">


After
<img width="1454" alt="Screenshot 2023-05-18 at 16 47 16" src="https://github.com/mathiazom/sit-rezervo-confgen/assets/26925695/2e3e2b68-ac1b-40fb-a7af-9fa614c055e5">
