### PR TITLE
Implement Week Navigation

### DIFF
--- a/components/AppBar.tsx
+++ b/components/AppBar.tsx
@@ -84,10 +84,10 @@ export default function AppBar({
                                 </Tooltip>
                                 <Button
                                     variant={"contained"}
-                                    startIcon={<CloudUploadIcon />}
+                                    startIcon={<CloudUploadIcon sx={{ color: "#fff" }} />}
                                     onClick={() => onUpdateConfig()}
                                 >
-                                    Oppdater
+                                    <Typography color={"#fff"}>Oppdater</Typography>
                                 </Button>
                             </Box>
                         ) : (

--- a/components/ClassCard/ClassCard.tsx
+++ b/components/ClassCard/ClassCard.tsx
@@ -49,7 +49,7 @@ const ClassCard = ({
     return (
         <Card
             sx={{
-                opacity: isInThePast ? 0.5 : 1,
+                opacity: isInThePast ? 0.6 : 1,
                 background: "none",
                 position: "relative",
                 borderLeft: `0.4rem solid ${classColorRGB(false)}`,
@@ -107,7 +107,7 @@ const ClassCard = ({
                     zIndex: -1,
                     backgroundColor: "white",
                     '[data-mui-color-scheme="dark"] &': {
-                        backgroundColor: "#111",
+                        backgroundColor: "#191919",
                     },
                 }}
             />

--- a/components/ClassCard/ClassCard.tsx
+++ b/components/ClassCard/ClassCard.tsx
@@ -44,9 +44,12 @@ const ClassCard = ({
 
     const classColorRGB = (dark: boolean) => `rgb(${hexWithOpacityToRgb(_class.color, 0.6, dark ? 0 : 255).join(",")})`;
 
+    const isInThePast = new Date(_class.from).getTime() < new Date().getTime();
+
     return (
         <Card
             sx={{
+                opacity: isInThePast ? 0.5 : 1,
                 background: "none",
                 position: "relative",
                 borderLeft: `0.4rem solid ${classColorRGB(false)}`,
@@ -57,19 +60,20 @@ const ClassCard = ({
         >
             <CardContent
                 className={"unselectable"}
-                onClick={selectable ? handleClick : undefined}
+                onClick={selectable && !isInThePast ? handleClick : undefined}
                 sx={{ paddingBottom: 1 }}
             >
                 <Box sx={{ display: "flex", justifyContent: "space-between" }}>
                     <Typography
                         sx={{
+                            textDecoration: isInThePast ? "line-through" : "none",
                             fontSize: "1.05rem",
                             ...(selected ? { fontWeight: "bold" } : {}),
                         }}
                     >
                         {_class.name}
                     </Typography>
-                    <ClassPopularityMeter popularity={popularity} />
+                    {!isInThePast && <ClassPopularityMeter popularity={popularity} />}
                 </Box>
                 <Typography sx={{ fontSize: "0.85rem" }} variant="body2" color="text.secondary">
                     {simpleTimeStringFromISO(_class.from)} - {simpleTimeStringFromISO(_class.to)}

--- a/components/ClassInfo.tsx
+++ b/components/ClassInfo.tsx
@@ -10,7 +10,7 @@ import { SitClass } from "../types/sitTypes";
 import { hexWithOpacityToRgb } from "../utils/colorUtils";
 import { ClassPopularity } from "../types/derivedTypes";
 
-export default function ClassInfo({ _class, popularity }: { _class: SitClass; popularity: ClassPopularity }) {
+export default function ClassInfo({ _class, classPopularity }: { _class: SitClass; classPopularity: ClassPopularity }) {
     const color = (dark: boolean) => `rgb(${hexWithOpacityToRgb(_class.color, 0.6, dark ? 0 : 255).join(",")})`;
 
     const isInThePast = new Date(_class.from).getTime() < new Date().getTime();
@@ -109,7 +109,7 @@ export default function ClassInfo({ _class, popularity }: { _class: SitClass; po
                     {_class.instructors.map((i) => i.name).join(", ")}
                 </Typography>
             </Box>
-            {popularity && !isInThePast && (
+            {!isInThePast && (
                 <Box
                     sx={{
                         display: "flex",
@@ -118,9 +118,9 @@ export default function ClassInfo({ _class, popularity }: { _class: SitClass; po
                         alignItems: "center",
                     }}
                 >
-                    <ClassPopularityMeter popularity={popularity} />
+                    <ClassPopularityMeter popularity={classPopularity} />
                     <Typography variant="body2" color="text.secondary">
-                        {popularity}
+                        {classPopularity}
                     </Typography>
                 </Box>
             )}

--- a/components/ClassInfo.tsx
+++ b/components/ClassInfo.tsx
@@ -13,6 +13,7 @@ import { ClassPopularity } from "../types/derivedTypes";
 export default function ClassInfo({ _class, popularity }: { _class: SitClass; popularity: ClassPopularity }) {
     const color = (dark: boolean) => `rgb(${hexWithOpacityToRgb(_class.color, 0.6, dark ? 0 : 255).join(",")})`;
 
+    const isInThePast = new Date(_class.from).getTime() < new Date().getTime();
     return (
         <Box
             sx={{
@@ -108,7 +109,7 @@ export default function ClassInfo({ _class, popularity }: { _class: SitClass; po
                     {_class.instructors.map((i) => i.name).join(", ")}
                 </Typography>
             </Box>
-            {popularity && (
+            {popularity && !isInThePast && (
                 <Box
                     sx={{
                         display: "flex",

--- a/components/ClassInfo.tsx
+++ b/components/ClassInfo.tsx
@@ -30,7 +30,7 @@ export default function ClassInfo({ _class, popularity }: { _class: SitClass; po
                 p: 4,
                 backgroundColor: "white",
                 '[data-mui-color-scheme="dark"] &': {
-                    backgroundColor: "#111",
+                    backgroundColor: "#181818",
                 },
             }}
         >

--- a/components/MobileConfigUpdateBar.tsx
+++ b/components/MobileConfigUpdateBar.tsx
@@ -1,4 +1,4 @@
-import { Box, CircularProgress, Fab } from "@mui/material";
+import { Box, CircularProgress, Fab, Typography } from "@mui/material";
 import UndoIcon from "@mui/icons-material/Undo";
 import CloudUploadIcon from "@mui/icons-material/CloudUpload";
 import React from "react";
@@ -42,8 +42,8 @@ export default function MobileConfigUpdateBar({
                         />
                     </Fab>
                     <Fab color={"primary"} variant="extended" onClick={() => onUpdateConfig()}>
-                        <CloudUploadIcon sx={{ mr: 1 }} />
-                        Oppdater
+                        <CloudUploadIcon sx={{ mr: 1, color: "#fff" }} />
+                        <Typography color={"#fff"}>Oppdater</Typography>
                     </Fab>
                 </>
             )}

--- a/components/Schedule.tsx
+++ b/components/Schedule.tsx
@@ -1,12 +1,10 @@
 import React from "react";
-import { Box, Button, Stack, Typography, useTheme } from "@mui/material";
+import { Box, Stack, Typography, useTheme } from "@mui/material";
 import ClassCard from "./ClassCard/ClassCard";
 import { SitClass, SitSchedule } from "../types/sitTypes";
-import { getWeekNumber, weekdayNameToNumber } from "../utils/timeUtils";
+import { weekdayNameToNumber } from "../utils/timeUtils";
 import { ActivityPopularity, ClassPopularity } from "../types/derivedTypes";
 import { sitClassRecurrentId } from "../lib/iBooking";
-import IconButton from "@mui/material/IconButton";
-import { ArrowBack, ArrowForward } from "@mui/icons-material";
 
 const Schedule = ({
     schedule,
@@ -15,7 +13,6 @@ const Schedule = ({
     selectedClassIds,
     onSelectedChanged,
     onInfo,
-    handleUpdateWeekOffset,
 }: {
     schedule: SitSchedule;
     activitiesPopularity: ActivityPopularity[];
@@ -25,8 +22,6 @@ const Schedule = ({
     onSelectedChanged: (classId: string, selected: boolean) => void;
     // eslint-disable-next-line no-unused-vars
     onInfo: (c: SitClass) => void;
-    // eslint-disable-next-line no-unused-vars
-    handleUpdateWeekOffset: (modifier: number) => void;
 }) => {
     const theme = useTheme();
 
@@ -36,19 +31,7 @@ const Schedule = ({
 
     return (
         <Stack direction={"column"}>
-            <Typography mt={2} align={"center"} variant={"caption"}>
-                Uke {getWeekNumber(new Date(schedule.days[0]?.date ?? ""))}
-            </Typography>
-            <Stack direction={"row"} justifyContent={"center"}>
-                <IconButton onClick={() => handleUpdateWeekOffset(-1)}>
-                    <ArrowBack />
-                </IconButton>
-                <Button onClick={() => handleUpdateWeekOffset(0)}>I dag</Button>
-                <IconButton onClick={() => handleUpdateWeekOffset(1)}>
-                    <ArrowForward />
-                </IconButton>
-            </Stack>
-            <Stack direction={"row"} margin={"auto"} spacing={2} px={2}>
+            <Stack direction={"row"} margin={"auto"} spacing={2} px={1}>
                 {schedule.days.map((day) => (
                     <Box key={day.date} width={180}>
                         <Box py={2}>

--- a/components/Schedule.tsx
+++ b/components/Schedule.tsx
@@ -1,10 +1,12 @@
 import React from "react";
-import { Box, Stack, Typography, useTheme } from "@mui/material";
+import { Box, Button, Stack, Typography, useTheme } from "@mui/material";
 import ClassCard from "./ClassCard/ClassCard";
 import { SitClass, SitSchedule } from "../types/sitTypes";
-import { weekdayNameToNumber } from "../utils/timeUtils";
+import { getWeekNumber, weekdayNameToNumber } from "../utils/timeUtils";
 import { ActivityPopularity, ClassPopularity } from "../types/derivedTypes";
 import { sitClassRecurrentId } from "../lib/iBooking";
+import IconButton from "@mui/material/IconButton";
+import { ArrowBack, ArrowForward } from "@mui/icons-material";
 
 const Schedule = ({
     schedule,
@@ -13,6 +15,7 @@ const Schedule = ({
     selectedClassIds,
     onSelectedChanged,
     onInfo,
+    handleUpdateWeekOffset,
 }: {
     schedule: SitSchedule;
     activitiesPopularity: ActivityPopularity[];
@@ -22,6 +25,8 @@ const Schedule = ({
     onSelectedChanged: (classId: string, selected: boolean) => void;
     // eslint-disable-next-line no-unused-vars
     onInfo: (c: SitClass) => void;
+    // eslint-disable-next-line no-unused-vars
+    handleUpdateWeekOffset: (modifier: number) => void;
 }) => {
     const theme = useTheme();
 
@@ -30,7 +35,19 @@ const Schedule = ({
             ?.popularity ?? ClassPopularity.Unknown;
 
     return (
-        <Stack>
+        <Stack direction={"column"}>
+            <Typography mt={2} align={"center"} variant={"caption"}>
+                Uke {getWeekNumber(new Date(schedule.days[0]?.date ?? ""))}
+            </Typography>
+            <Stack direction={"row"} justifyContent={"center"}>
+                <IconButton onClick={() => handleUpdateWeekOffset(-1)}>
+                    <ArrowBack />
+                </IconButton>
+                <Button onClick={() => handleUpdateWeekOffset(0)}>I dag</Button>
+                <IconButton onClick={() => handleUpdateWeekOffset(1)}>
+                    <ArrowForward />
+                </IconButton>
+            </Stack>
             <Stack direction={"row"} margin={"auto"} spacing={2} px={2}>
                 {schedule.days.map((day) => (
                     <Box key={day.date} width={180}>

--- a/components/Schedule.tsx
+++ b/components/Schedule.tsx
@@ -1,10 +1,11 @@
 import React from "react";
-import { Box, Stack, Typography, useTheme } from "@mui/material";
+import { Box, Chip, Stack, Typography, useTheme } from "@mui/material";
 import ClassCard from "./ClassCard/ClassCard";
 import { SitClass, SitSchedule } from "../types/sitTypes";
 import { weekdayNameToNumber } from "../utils/timeUtils";
 import { ActivityPopularity, ClassPopularity } from "../types/derivedTypes";
 import { sitClassRecurrentId } from "../lib/iBooking";
+import { DateTime } from "luxon";
 
 const Schedule = ({
     schedule,
@@ -29,14 +30,26 @@ const Schedule = ({
         activitiesPopularity.find((activityPopularity) => activityPopularity.activityId === _class.activityId)
             ?.popularity ?? ClassPopularity.Unknown;
 
+    const isToday = (dateStr: string) => DateTime.fromISO(dateStr).startOf("day").equals(DateTime.now().startOf("day"));
+
     return (
         <Stack direction={"column"}>
             <Stack direction={"row"} margin={"auto"} spacing={2} px={1}>
                 {schedule.days.map((day) => (
                     <Box key={day.date} width={180}>
-                        <Box py={2}>
+                        <Box
+                            py={2}
+                            sx={{ opacity: DateTime.fromISO(day.date).endOf("day") > DateTime.now() ? 1 : 0.5 }}
+                        >
                             <Typography variant="h6" component="div">
-                                {day.dayName}
+                                {day.dayName}{" "}
+                                {isToday(day.date) && (
+                                    <Chip
+                                        size={"small"}
+                                        sx={{ backgroundColor: theme.palette.primary.dark, color: "#fff" }}
+                                        label="I dag"
+                                    />
+                                )}
                             </Typography>
                             <Typography
                                 variant="h6"

--- a/components/Schedule.tsx
+++ b/components/Schedule.tsx
@@ -2,21 +2,20 @@ import React from "react";
 import { Box, Chip, Stack, Typography, useTheme } from "@mui/material";
 import ClassCard from "./ClassCard/ClassCard";
 import { SitClass, SitSchedule } from "../types/sitTypes";
-import { weekdayNameToNumber } from "../utils/timeUtils";
-import { ActivityPopularity, ClassPopularity } from "../types/derivedTypes";
+import { ClassPopularityIndex, ClassPopularity } from "../types/derivedTypes";
 import { sitClassRecurrentId } from "../lib/iBooking";
 import { DateTime } from "luxon";
 
 const Schedule = ({
     schedule,
-    activitiesPopularity,
+    classPopularityIndex,
     selectable,
     selectedClassIds,
     onSelectedChanged,
     onInfo,
 }: {
     schedule: SitSchedule;
-    activitiesPopularity: ActivityPopularity[];
+    classPopularityIndex: ClassPopularityIndex;
     selectable: boolean;
     selectedClassIds: string[];
     // eslint-disable-next-line no-unused-vars
@@ -25,10 +24,6 @@ const Schedule = ({
     onInfo: (c: SitClass) => void;
 }) => {
     const theme = useTheme();
-
-    const lookupClassPopularity = (_class: SitClass) =>
-        activitiesPopularity.find((activityPopularity) => activityPopularity.activityId === _class.activityId)
-            ?.popularity ?? ClassPopularity.Unknown;
 
     const isToday = (dateStr: string) => DateTime.fromISO(dateStr).startOf("day").equals(DateTime.now().startOf("day"));
 
@@ -63,24 +58,23 @@ const Schedule = ({
                             </Typography>
                         </Box>
                         {day.classes.length > 0 ? (
-                            day.classes.map((_class) => {
-                                _class.weekday = weekdayNameToNumber(day.dayName);
-                                return (
-                                    <Box key={_class.id} mb={1}>
-                                        <ClassCard
-                                            _class={_class}
-                                            popularity={lookupClassPopularity(_class)}
-                                            selectable={selectable}
-                                            selected={selectedClassIds.includes(sitClassRecurrentId(_class))}
-                                            onSelectedChanged={(s) => onSelectedChanged(sitClassRecurrentId(_class), s)}
-                                            onInfo={() => onInfo(_class)}
-                                            // onSettings={() =>
-                                            //     setSettingsClass(_class)
-                                            // }
-                                        />
-                                    </Box>
-                                );
-                            })
+                            day.classes.map((_class) => (
+                                <Box key={_class.id} mb={1}>
+                                    <ClassCard
+                                        _class={_class}
+                                        popularity={
+                                            classPopularityIndex[sitClassRecurrentId(_class)] ?? ClassPopularity.Unknown
+                                        }
+                                        selectable={selectable}
+                                        selected={selectedClassIds.includes(sitClassRecurrentId(_class))}
+                                        onSelectedChanged={(s) => onSelectedChanged(sitClassRecurrentId(_class), s)}
+                                        onInfo={() => onInfo(_class)}
+                                        // onSettings={() =>
+                                        //     setSettingsClass(_class)
+                                        // }
+                                    />
+                                </Box>
+                            ))
                         ) : (
                             <p>Ingen gruppetimer</p>
                         )}

--- a/lib/iBooking.ts
+++ b/lib/iBooking.ts
@@ -34,15 +34,18 @@ async function fetchScheduleWithDayOffset(token: string, dayOffset: number): Pro
     return await scheduleResponse.json();
 }
 
-export async function fetchSchedule() {
+export async function fetchSchedule(weekOffset: number) {
     const token = await fetchPublicToken();
+
+    const dayNumber = new Date().getDay();
+    const mondayOffset = dayNumber === 0 ? 6 : dayNumber - 1;
 
     return {
         // Use two fetches to retrieve schedule for the next 7 days
         days: [
             // Use offset -1 to fetch all today's events, not just the ones in the future
-            ...(await fetchScheduleWithDayOffset(token, -1)).days.slice(1),
-            ...(await fetchScheduleWithDayOffset(token, 3)).days,
+            ...(await fetchScheduleWithDayOffset(token, -1 - mondayOffset + weekOffset * 7)).days.slice(1, 4),
+            ...(await fetchScheduleWithDayOffset(token, 3 - mondayOffset + weekOffset * 7)).days.slice(0, 4),
         ],
     };
 }

--- a/lib/iBooking.ts
+++ b/lib/iBooking.ts
@@ -1,5 +1,5 @@
 import { GROUP_BOOKING_URL } from "../config/config";
-import { SitClass, SitSchedule, SitScheduleDay } from "../types/sitTypes";
+import { SitClass, SitSchedule } from "../types/sitTypes";
 import { ClassConfig } from "../types/rezervoTypes";
 import { weekdayNameToNumber } from "../utils/timeUtils";
 
@@ -33,7 +33,12 @@ async function fetchScheduleWithDayOffset(token: string, dayOffset: number): Pro
     return await scheduleResponse.json();
 }
 
-export async function fetchSchedule(weekOffset: number): Promise<{ days: SitScheduleDay[] }> {
+export async function fetchSchedules(weekOffsets: number[]): Promise<{ [weekOffset: number]: SitSchedule }> {
+    const weekOffsetToSchedule = (o: number) => fetchSchedule(o).then((s) => ({ [o]: s }));
+    return (await Promise.all(weekOffsets.map(weekOffsetToSchedule))).reduce((acc, o) => ({ ...acc, ...o }), {});
+}
+
+export async function fetchSchedule(weekOffset: number): Promise<SitSchedule> {
     const token = await fetchPublicToken();
 
     const dayNumber = new Date().getDay();

--- a/lib/popularity.ts
+++ b/lib/popularity.ts
@@ -1,9 +1,19 @@
-import { SitClass } from "../types/sitTypes";
-import { ClassPopularity } from "../types/derivedTypes";
+import { SitClass, SitSchedule } from "../types/sitTypes";
+import { ClassPopularityIndex, ClassPopularity } from "../types/derivedTypes";
+import { sitClassRecurrentId } from "./iBooking";
 
 export function determineClassPopularity(sitClass: SitClass) {
     if (!sitClass || sitClass.available === undefined) return ClassPopularity.Unknown;
     if (sitClass.available <= 0) return ClassPopularity.High;
     if (sitClass.available / sitClass.capacity <= 0.2) return ClassPopularity.Medium;
     return ClassPopularity.Low;
+}
+
+export async function createClassPopularityIndex(previousWeekSchedule: SitSchedule): Promise<ClassPopularityIndex> {
+    return previousWeekSchedule.days.reduce((popularityIndex, nextDay) => {
+        for (const _class of nextDay.classes) {
+            popularityIndex[sitClassRecurrentId(_class)] = determineClassPopularity(_class);
+        }
+        return popularityIndex;
+    }, {} as ClassPopularityIndex);
 }

--- a/lib/popularity.ts
+++ b/lib/popularity.ts
@@ -10,10 +10,13 @@ export function determineClassPopularity(sitClass: SitClass) {
 }
 
 export async function createClassPopularityIndex(previousWeekSchedule: SitSchedule): Promise<ClassPopularityIndex> {
-    return previousWeekSchedule.days.reduce((popularityIndex, nextDay) => {
-        for (const _class of nextDay.classes) {
-            popularityIndex[sitClassRecurrentId(_class)] = determineClassPopularity(_class);
-        }
-        return popularityIndex;
-    }, {} as ClassPopularityIndex);
+    return previousWeekSchedule.days
+        .flatMap((d) => d.classes)
+        .reduce(
+            (popularityIndex, _class) => ({
+                ...popularityIndex,
+                [sitClassRecurrentId(_class)]: determineClassPopularity(_class),
+            }),
+            {} as ClassPopularityIndex
+        );
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
         "@types/json-diff": "^0.9.1",
         "axios": "^0.27.2",
         "json-diff": "^1.0.3",
+        "luxon": "^3.3.0",
         "next": "^12.3.0",
         "react": "18.2.0",
         "react-diff-viewer": "^3.1.1",
@@ -27,6 +28,7 @@
         "react-use-clipboard": "^1.0.9"
     },
     "devDependencies": {
+        "@types/luxon": "^3.3.0",
         "@types/node": "18.0.0",
         "@types/react": "18.0.14",
         "@types/react-dom": "18.0.5",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -14,7 +14,7 @@ const theme = experimental_extendTheme({
                     light: "#6fbf73",
                     main: "#4caf50",
                     dark: "#357a38",
-                    contrastText: "#fff",
+                    contrastText: "#000",
                 },
                 secondary: {
                     light: "#ff7961",
@@ -40,7 +40,7 @@ const theme = experimental_extendTheme({
                     light: "#ff7961",
                     main: "#f44336",
                     dark: "#ba000d",
-                    contrastText: "#000",
+                    contrastText: "#fff",
                 },
                 background: {
                     default: "#000",

--- a/pages/api/schedule.ts
+++ b/pages/api/schedule.ts
@@ -1,0 +1,12 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { fetchSchedule } from "../../lib/iBooking";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    const weekOffset = JSON.parse(req.body)["weekOffset"];
+    if (weekOffset === undefined) {
+        return res.status(400).json({ message: "weekOffset is a required parameter" });
+    }
+
+    const result = await fetchSchedule(weekOffset);
+    return res.json(result);
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,6 @@
 import type { NextPage } from "next";
 import React, { memo, useCallback, useEffect, useMemo, useState } from "react";
-import { Box, Container, Divider, Modal, Stack } from "@mui/material";
+import { Button, Box, Container, Divider, Modal, Stack } from "@mui/material";
 import Head from "next/head";
 import Schedule from "../components/Schedule";
 import { classConfigRecurrentId, fetchActivityPopularity, fetchSchedule, sitClassRecurrentId } from "../lib/iBooking";
@@ -15,6 +15,8 @@ import AppBar from "../components/AppBar";
 import MobileConfigUpdateBar from "../components/MobileConfigUpdateBar";
 import ClassInfo from "../components/ClassInfo";
 import Agenda from "../components/Agenda";
+import { ArrowBack, ArrowForward } from "@mui/icons-material";
+import { DateTime } from "luxon";
 
 // Memoize to avoid redundant schedule re-render on class selection change
 const ScheduleMemo = memo(Schedule);
@@ -263,7 +265,7 @@ const Index: NextPage<{
                 <meta name="msapplication-TileColor" content="#da532c" />
                 <meta name="theme-color" content="#ffffff" />
             </Head>
-            <Stack divider={<Divider orientation="horizontal" flexItem />}>
+            <Stack>
                 <Box display={"flex"} justifyContent={"center"}>
                     <Box width={1388}>
                         <AppBar
@@ -277,6 +279,20 @@ const Index: NextPage<{
                         />
                     </Box>
                 </Box>
+                <Stack>
+                    <Stack direction={"row"} justifyContent={"center"}>
+                        <Button onClick={() => handleUpdateWeekOffset(-1)} startIcon={<ArrowBack />}>{`W${
+                            DateTime.fromISO(currentSchedule.days[0]!.date).minus({ weeks: 1 }).weekNumber
+                        }`}</Button>
+                        <Button disabled={weekOffset === 0} onClick={() => handleUpdateWeekOffset(0)}>
+                            I dag
+                        </Button>
+                        <Button onClick={() => handleUpdateWeekOffset(1)} endIcon={<ArrowForward />}>{`W${
+                            DateTime.fromISO(currentSchedule.days[0]!.date).plus({ weeks: 1 }).weekNumber
+                        }`}</Button>
+                    </Stack>
+                </Stack>
+                <Divider orientation="horizontal" flexItem />
                 <Stack direction={{ xs: "column", md: "row" }} divider={<Divider orientation="vertical" flexItem />}>
                     <Container maxWidth={false} sx={{ height: "92vh", overflow: "auto", padding: "0 !important" }}>
                         <ScheduleMemo
@@ -286,7 +302,6 @@ const Index: NextPage<{
                             selectedClassIds={selectedClassIds}
                             onSelectedChanged={onSelectedChanged}
                             onInfo={setModalClass}
-                            handleUpdateWeekOffset={handleUpdateWeekOffset}
                         />
                     </Container>
                 </Stack>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,7 +3,7 @@ import React, { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { Box, Button, Container, Divider, Modal, Stack, Typography, useTheme } from "@mui/material";
 import Head from "next/head";
 import Schedule from "../components/Schedule";
-import { classConfigRecurrentId, fetchSchedule, sitClassRecurrentId } from "../lib/iBooking";
+import { classConfigRecurrentId, fetchSchedules, sitClassRecurrentId } from "../lib/iBooking";
 import { ClassPopularityIndex, ClassPopularity } from "../types/derivedTypes";
 import { SitClass, SitSchedule } from "../types/sitTypes";
 import { useUser } from "@auth0/nextjs-auth0/client";
@@ -23,14 +23,8 @@ import { createClassPopularityIndex } from "../lib/popularity";
 const ScheduleMemo = memo(Schedule);
 
 export async function getStaticProps() {
-    const initialCachedSchedules = {
-        [-1]: await fetchSchedule(-1),
-        [0]: await fetchSchedule(0),
-        [1]: await fetchSchedule(1),
-        [2]: await fetchSchedule(2),
-        [3]: await fetchSchedule(3),
-    };
-    const classPopularityIndex = await createClassPopularityIndex(initialCachedSchedules[-1]);
+    const initialCachedSchedules = await fetchSchedules([-1, 0, 1, 2, 3]);
+    const classPopularityIndex = await createClassPopularityIndex(initialCachedSchedules[-1]!);
     const invalidationTimeInSeconds = 60 * 60;
 
     return {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,6 @@
 import type { NextPage } from "next";
 import React, { memo, useCallback, useEffect, useMemo, useState } from "react";
-import { Button, Box, Container, Divider, Modal, Stack } from "@mui/material";
+import { Button, Box, Container, Divider, Modal, Stack, Typography, useTheme } from "@mui/material";
 import Head from "next/head";
 import Schedule from "../components/Schedule";
 import { classConfigRecurrentId, fetchActivityPopularity, fetchSchedule, sitClassRecurrentId } from "../lib/iBooking";
@@ -46,6 +46,7 @@ const Index: NextPage<{
     activitiesPopularity: ActivityPopularity[];
 }> = ({ initialCachedSchedules, activitiesPopularity }) => {
     const router = useRouter();
+    const theme = useTheme();
 
     const { user } = useUser();
 
@@ -280,16 +281,38 @@ const Index: NextPage<{
                     </Box>
                 </Box>
                 <Stack>
-                    <Stack direction={"row"} justifyContent={"center"}>
-                        <Button onClick={() => handleUpdateWeekOffset(-1)} startIcon={<ArrowBack />}>{`W${
-                            DateTime.fromISO(currentSchedule.days[0]!.date).minus({ weeks: 1 }).weekNumber
-                        }`}</Button>
-                        <Button disabled={weekOffset === 0} onClick={() => handleUpdateWeekOffset(0)}>
+                    <Stack
+                        direction={"row"}
+                        justifyContent={"center"}
+                        alignItems={"center"}
+                        mb={1}
+                        sx={{ position: "relative" }}
+                    >
+                        <Button variant={"outlined"} size={"small"} onClick={() => handleUpdateWeekOffset(-1)}>
+                            <ArrowBack />
+                        </Button>
+                        <Typography
+                            sx={{ opacity: 0.7 }}
+                            mx={2}
+                            variant={"subtitle2"}
+                            color={theme.palette.primary.contrastText}
+                        >{`UKE ${DateTime.fromISO(currentSchedule.days[0]!.date).weekNumber}`}</Typography>
+                        <Button variant={"outlined"} size={"small"} onClick={() => handleUpdateWeekOffset(1)}>
+                            <ArrowForward />
+                        </Button>
+                        <Button
+                            sx={{
+                                ml: 1,
+                                position: { xs: "absolute", md: "inherit" },
+                                right: { xs: 10, md: "inherit" },
+                            }}
+                            variant={"outlined"}
+                            size={"small"}
+                            disabled={weekOffset === 0}
+                            onClick={() => handleUpdateWeekOffset(0)}
+                        >
                             I dag
                         </Button>
-                        <Button onClick={() => handleUpdateWeekOffset(1)} endIcon={<ArrowForward />}>{`W${
-                            DateTime.fromISO(currentSchedule.days[0]!.date).plus({ weeks: 1 }).weekNumber
-                        }`}</Button>
                     </Stack>
                 </Stack>
                 <Divider orientation="horizontal" flexItem />

--- a/types/derivedTypes.ts
+++ b/types/derivedTypes.ts
@@ -5,7 +5,6 @@ export enum ClassPopularity {
     High = "Denne timen er vanligvis full.",
 }
 
-export type ActivityPopularity = {
-    activityId: number;
-    popularity: ClassPopularity;
+export type ClassPopularityIndex = {
+    [recurrentId: string]: ClassPopularity;
 };

--- a/utils/timeUtils.ts
+++ b/utils/timeUtils.ts
@@ -25,16 +25,3 @@ export function weekdayNameToNumber(weekdayName: string): number {
 
     return weekdayNumber;
 }
-
-// In Mathias we trust
-export function getWeekNumber(d: Date): number {
-    // Copy date so don't modify original
-    d = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()));
-    // Set to nearest Thursday: current date + 4 - current day number
-    // Make Sunday's day number 7
-    d.setUTCDate(d.getUTCDate() + 4 - (d.getUTCDay() || 7));
-    // Get first day of year
-    const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
-    // Calculate full weeks to nearest Thursday
-    return Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
-}

--- a/utils/timeUtils.ts
+++ b/utils/timeUtils.ts
@@ -25,3 +25,16 @@ export function weekdayNameToNumber(weekdayName: string): number {
 
     return weekdayNumber;
 }
+
+// In Mathias we trust
+export function getWeekNumber(d: Date): number {
+    // Copy date so don't modify original
+    d = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()));
+    // Set to nearest Thursday: current date + 4 - current day number
+    // Make Sunday's day number 7
+    d.setUTCDate(d.getUTCDate() + 4 - (d.getUTCDay() || 7));
+    // Get first day of year
+    const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+    // Calculate full weeks to nearest Thursday
+    return Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -570,6 +570,11 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
+"@types/luxon@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@types/luxon/-/luxon-3.3.0.tgz#a61043a62c0a72696c73a0a305c544c96501e006"
+  integrity sha512-uKRI5QORDnrGFYgcdAVnHvEIvEZ8noTpP/Bg+HeUzZghwinDlIS87DEenV5r1YoOF9G4x600YsUXLWZ19rmTmg==
+
 "@types/node@18.0.0":
   version "18.0.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.0.0.tgz#67c7b724e1bcdd7a8821ce0d5ee184d3b4dd525a"
@@ -2326,6 +2331,11 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+luxon@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.3.0.tgz#d73ab5b5d2b49a461c47cedbc7e73309b4805b48"
+  integrity sha512-An0UCfG/rSiqtAIiBPO0Y9/zAnHUZxAMiCpTd5h2smgsj7GGmcenvrvww2cqNA8/4A5ZrD1gJpHN2mIHZQF+Mg==
 
 memoize-one@^5.0.4:
   version "5.2.1"


### PR DESCRIPTION
With these changes, it is now possible to navigate between weeks. Each week starts with a Monday, and you always load into the current week. This weeks schedule, along with one week in the past and three weeks in the future are cached on static site generation. If the user wants to go to different weeks, these are loaded in as we go.

Classes that are in the past have lower opacity, and have strike through in their titles. In addition, popularity is hidden, since that does not make sense for a class that is in the past.

Ended up having to use the Luxon time library to determine week numbers, since the standard date library was not sufficient. (And Dayjs did not handle years with 53 weeks well) 

Before
<img width="1478" alt="image" src="https://github.com/mathiazom/sit-rezervo-confgen/assets/26925695/424dde3e-ea65-485a-aac7-d497e2b031b0">

After
https://github.com/mathiazom/sit-rezervo-confgen/assets/26925695/1c6e4694-64d3-4e8d-ac4e-3e061b03665e