### PR TITLE
refactor(index): extract modals to separate components

### DIFF
--- a/components/modals/AgendaModal.tsx
+++ b/components/modals/AgendaModal.tsx
@@ -1,0 +1,46 @@
+import { Modal } from "@mui/material";
+import { classConfigRecurrentId, sitClassRecurrentId } from "../../lib/iBooking";
+import React, { Dispatch, SetStateAction } from "react";
+import Agenda from "../Agenda";
+import { UserConfig } from "../../types/rezervoTypes";
+import { SitClass } from "../../types/sitTypes";
+
+const AgendaModal = ({
+    open,
+    setOpen,
+    userConfig,
+    classes,
+    selectedClassIds,
+    onInfo,
+    onSelectedChanged,
+}: {
+    open: boolean;
+    setOpen: Dispatch<SetStateAction<boolean>>;
+    userConfig: UserConfig | undefined;
+    classes: SitClass[];
+    selectedClassIds: string[] | null;
+    onInfo: Dispatch<SetStateAction<SitClass | null>>;
+    // eslint-disable-next-line no-unused-vars
+    onSelectedChanged: (classId: string, selected: boolean) => void;
+}) => {
+    return (
+        <Modal open={open} onClose={() => setOpen(false)}>
+            <>
+                {userConfig?.classes && (
+                    <Agenda
+                        agendaClasses={userConfig.classes.map((c) => ({
+                            config: c,
+                            sitClass: classes.find((sc) => sitClassRecurrentId(sc) === classConfigRecurrentId(c)),
+                            markedForDeletion:
+                                selectedClassIds != null && !selectedClassIds.includes(classConfigRecurrentId(c)),
+                        }))}
+                        onInfo={onInfo}
+                        onSetToDelete={(c, toDelete) => onSelectedChanged(classConfigRecurrentId(c), !toDelete)}
+                    />
+                )}
+            </>
+        </Modal>
+    );
+};
+
+export default AgendaModal;

--- a/components/modals/ClassInfoModal.tsx
+++ b/components/modals/ClassInfoModal.tsx
@@ -1,0 +1,47 @@
+import { Modal } from "@mui/material";
+import ClassInfo from "../ClassInfo";
+import { sitClassRecurrentId } from "../../lib/iBooking";
+import { AllConfigsIndex, ClassPopularity, ClassPopularityIndex, UserSessionsIndex } from "../../types/rezervoTypes";
+import React, { Dispatch, SetStateAction } from "react";
+import { SitClass } from "../../types/sitTypes";
+
+const ClassInfoModal = ({
+    classInfoClass,
+    setClassInfoClass,
+    classPopularityIndex,
+    allConfigsIndex,
+    userSessionsIndex,
+    bookClass,
+    cancelBooking,
+}: {
+    classInfoClass: SitClass | null;
+    setClassInfoClass: Dispatch<SetStateAction<SitClass | null>>;
+    classPopularityIndex: ClassPopularityIndex;
+    allConfigsIndex: AllConfigsIndex | undefined;
+    userSessionsIndex: UserSessionsIndex | undefined;
+    // eslint-disable-next-line no-unused-vars
+    bookClass: (classId: number) => Promise<UserSessionsIndex | undefined>;
+    // eslint-disable-next-line no-unused-vars
+    cancelBooking: (classId: number) => Promise<UserSessionsIndex | undefined>;
+}) => {
+    return (
+        <Modal open={classInfoClass != null} onClose={() => setClassInfoClass(null)}>
+            <>
+                {classInfoClass && (
+                    <ClassInfo
+                        _class={classInfoClass}
+                        classPopularity={
+                            classPopularityIndex[sitClassRecurrentId(classInfoClass)] ?? ClassPopularity.Unknown
+                        }
+                        configUsers={allConfigsIndex ? allConfigsIndex[sitClassRecurrentId(classInfoClass)] ?? [] : []}
+                        userSessions={userSessionsIndex ? userSessionsIndex[classInfoClass.id] ?? [] : []}
+                        onBook={() => bookClass(classInfoClass.id)}
+                        onCancelBooking={() => cancelBooking(classInfoClass.id)}
+                    />
+                )}
+            </>
+        </Modal>
+    );
+};
+
+export default ClassInfoModal;

--- a/components/modals/SettingsModal.tsx
+++ b/components/modals/SettingsModal.tsx
@@ -1,0 +1,41 @@
+import { Modal } from "@mui/material";
+import React, { Dispatch, SetStateAction } from "react";
+import { NotificationsConfig } from "../../types/rezervoTypes";
+import Settings from "../Settings";
+
+const SettingsModal = ({
+    open,
+    setOpen,
+    bookingActive,
+    bookingActiveLoading,
+    onBookingActiveChanged,
+    notificationsConfig,
+    notificationsConfigLoading,
+    onNotificationsConfigChanged,
+}: {
+    open: boolean;
+    setOpen: Dispatch<SetStateAction<boolean>>;
+    bookingActive: boolean;
+    bookingActiveLoading: boolean;
+    // eslint-disable-next-line no-unused-vars
+    onBookingActiveChanged: (active: boolean) => void;
+    notificationsConfig: NotificationsConfig | null;
+    notificationsConfigLoading: boolean;
+    // eslint-disable-next-line no-unused-vars
+    onNotificationsConfigChanged: (notificationsConfig: NotificationsConfig) => void;
+}) => {
+    return (
+        <Modal open={open} onClose={() => setOpen(false)}>
+            <Settings
+                bookingActive={bookingActive}
+                bookingActiveLoading={bookingActiveLoading}
+                onBookingActiveChanged={onBookingActiveChanged}
+                notificationsConfig={notificationsConfig}
+                notificationsConfigLoading={notificationsConfigLoading}
+                onNotificationsConfigChanged={onNotificationsConfigChanged}
+            />
+        </Modal>
+    );
+};
+
+export default SettingsModal;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,29 +1,23 @@
 import type { NextPage } from "next";
 import React, { memo, useCallback, useEffect, useMemo, useState } from "react";
-import { Box, Divider, Modal, Stack } from "@mui/material";
+import { Box, Divider, Stack } from "@mui/material";
 import Schedule from "../components/Schedule";
 import { classConfigRecurrentId, fetchSchedules, sitClassRecurrentId } from "../lib/iBooking";
 import { SitClass, SitSchedule } from "../types/sitTypes";
-import {
-    ClassConfig,
-    ClassPopularity,
-    ClassPopularityIndex,
-    ConfigPayload,
-    NotificationsConfig,
-} from "../types/rezervoTypes";
+import { ClassConfig, ClassPopularityIndex, ConfigPayload, NotificationsConfig } from "../types/rezervoTypes";
 import { arraysAreEqual } from "../utils/arrayUtils";
-import Settings from "../components/Settings";
 import { useRouter } from "next/router";
 import AppBar from "../components/AppBar";
 import MobileConfigUpdateBar from "../components/MobileConfigUpdateBar";
-import ClassInfo from "../components/ClassInfo";
-import Agenda from "../components/Agenda";
 import { createClassPopularityIndex } from "../lib/popularity";
 import WeekNavigator from "../components/WeekNavigator";
 import { DateTime } from "luxon";
 import { useUserConfig } from "../hooks/useUserConfig";
 import { useUserSessions } from "../hooks/useUserSessions";
 import PageHead from "../components/PageHead";
+import ClassInfoModal from "../components/modals/ClassInfoModal";
+import AgendaModal from "../components/modals/AgendaModal";
+import SettingsModal from "../components/modals/SettingsModal";
 
 // Memoize to avoid redundant schedule re-render on class selection change
 const ScheduleMemo = memo(Schedule);
@@ -269,50 +263,34 @@ const Index: NextPage<{
                     onUndoSelectionChanges={() => setSelectedClassIds(originalSelectedClassIds)}
                 />
             </Stack>
-            <Modal open={classInfoClass != null} onClose={() => setClassInfoClass(null)}>
-                <>
-                    {classInfoClass && (
-                        <ClassInfo
-                            _class={classInfoClass}
-                            classPopularity={
-                                classPopularityIndex[sitClassRecurrentId(classInfoClass)] ?? ClassPopularity.Unknown
-                            }
-                            configUsers={
-                                allConfigsIndex ? allConfigsIndex[sitClassRecurrentId(classInfoClass)] ?? [] : []
-                            }
-                            userSessions={userSessionsIndex ? userSessionsIndex[classInfoClass.id] ?? [] : []}
-                            onBook={() => bookClass(classInfoClass.id)}
-                            onCancelBooking={() => cancelBooking(classInfoClass.id)}
-                        />
-                    )}
-                </>
-            </Modal>
-            <Modal open={isAgendaOpen} onClose={() => setIsAgendaOpen(false)}>
-                <>
-                    {userConfig?.classes && (
-                        <Agenda
-                            agendaClasses={userConfig.classes.map((c) => ({
-                                config: c,
-                                sitClass: classes.find((sc) => sitClassRecurrentId(sc) === classConfigRecurrentId(c)),
-                                markedForDeletion:
-                                    selectedClassIds != null && !selectedClassIds.includes(classConfigRecurrentId(c)),
-                            }))}
-                            onInfo={setClassInfoClass}
-                            onSetToDelete={(c, toDelete) => onSelectedChanged(classConfigRecurrentId(c), !toDelete)}
-                        />
-                    )}
-                </>
-            </Modal>
-            <Modal open={isSettingsOpen} onClose={() => setIsSettingsOpen(false)}>
-                <Settings
-                    bookingActive={userConfigActive}
-                    bookingActiveLoading={userConfigActiveLoading}
-                    onBookingActiveChanged={putConfigActive}
-                    notificationsConfig={notificationsConfig}
-                    notificationsConfigLoading={notificationsConfigLoading}
-                    onNotificationsConfigChanged={putNotificationsConfig}
-                />
-            </Modal>
+            <ClassInfoModal
+                classInfoClass={classInfoClass}
+                setClassInfoClass={setClassInfoClass}
+                classPopularityIndex={classPopularityIndex}
+                allConfigsIndex={allConfigsIndex}
+                userSessionsIndex={userSessionsIndex}
+                bookClass={bookClass}
+                cancelBooking={cancelBooking}
+            />
+            <AgendaModal
+                open={isAgendaOpen}
+                setOpen={setIsAgendaOpen}
+                userConfig={userConfig}
+                classes={classes}
+                selectedClassIds={selectedClassIds}
+                onInfo={setClassInfoClass}
+                onSelectedChanged={onSelectedChanged}
+            />
+            <SettingsModal
+                open={isSettingsOpen}
+                setOpen={setIsSettingsOpen}
+                bookingActive={userConfigActive}
+                bookingActiveLoading={userConfigActiveLoading}
+                onBookingActiveChanged={putConfigActive}
+                notificationsConfig={notificationsConfig}
+                notificationsConfigLoading={notificationsConfigLoading}
+                onNotificationsConfigChanged={putNotificationsConfig}
+            />
         </>
     );
 };


### PR DESCRIPTION
With this PR, I extract the logic for the Modals in Index.tsx to separate components. This is a small step in the larger task of generalizing `sit-rezervo-confgen` to support multiple companies. This change hides the internal logic of the modals, and I opted to make a component for each modal for completeness (even though the `SettingsModal` is mostly just passing props down the tree). However, it does a really nice job hiding complex logic for the `AgendaModal` and `ClassInfoModal`.