### PR TITLE
Move Component Specific Logic From Index To Their Respective Components

### DIFF
--- a/components/AppBar.tsx
+++ b/components/AppBar.tsx
@@ -37,130 +37,134 @@ export default function AppBar({
     const { user, isLoading } = useUser();
 
     return (
-        <Box display="flex" py={2} alignItems={"center"}>
-            <Typography
-                component="div"
-                pl={2}
-                sx={{
-                    fontSize: { xs: "1.2rem", sm: "1.8rem" },
-                    display: { xs: "none", md: "block" },
-                }}
-            >
-                <strong style={{ color: theme.palette.primary.main }}>sit-rezervo</strong>
-            </Typography>
-            <Box sx={{ marginLeft: "auto", marginRight: { xs: 1, md: 2 } }}>
-                {isLoading ? (
-                    <CircularProgress size={26} thickness={6} />
-                ) : user ? (
-                    <Box
+        <Box display={"flex"} justifyContent={"center"}>
+            <Box width={1388}>
+                <Box display="flex" py={2} alignItems={"center"}>
+                    <Typography
+                        component="div"
+                        pl={2}
                         sx={{
-                            display: "flex",
-                            alignItems: "center",
-                            gap: { xs: 1, md: 1.5 },
+                            fontSize: { xs: "1.2rem", sm: "1.8rem" },
+                            display: { xs: "none", md: "block" },
                         }}
                     >
-                        {isConfigError ? (
-                            <Box mr={1.5}>
-                                <Tooltip title={"Feilet"}>
-                                    <Badge
-                                        overlap={"circular"}
-                                        badgeContent={<ErrorRoundedIcon fontSize={"small"} color={"error"} />}
-                                    >
-                                        <CloudOffRoundedIcon color={"disabled"} />
-                                    </Badge>
-                                </Tooltip>
-                            </Box>
-                        ) : isLoadingConfig ? (
-                            <CircularProgress
+                        <strong style={{ color: theme.palette.primary.main }}>sit-rezervo</strong>
+                    </Typography>
+                    <Box sx={{ marginLeft: "auto", marginRight: { xs: 1, md: 2 } }}>
+                        {isLoading ? (
+                            <CircularProgress size={26} thickness={6} />
+                        ) : user ? (
+                            <Box
                                 sx={{
-                                    mr: 1,
-                                    display: {
-                                        xs: "none",
-                                        sm: "flex",
-                                    },
+                                    display: "flex",
+                                    alignItems: "center",
+                                    gap: { xs: 1, md: 1.5 },
                                 }}
-                                size={26}
-                                thickness={6}
-                            />
-                        ) : (
-                            <>
-                                {changed ? (
-                                    <Box
+                            >
+                                {isConfigError ? (
+                                    <Box mr={1.5}>
+                                        <Tooltip title={"Feilet"}>
+                                            <Badge
+                                                overlap={"circular"}
+                                                badgeContent={<ErrorRoundedIcon fontSize={"small"} color={"error"} />}
+                                            >
+                                                <CloudOffRoundedIcon color={"disabled"} />
+                                            </Badge>
+                                        </Tooltip>
+                                    </Box>
+                                ) : isLoadingConfig ? (
+                                    <CircularProgress
                                         sx={{
+                                            mr: 1,
                                             display: {
                                                 xs: "none",
                                                 sm: "flex",
                                             },
-                                            alignItems: "center",
-                                            gap: 1,
                                         }}
-                                    >
-                                        <Tooltip title={"Angre"}>
-                                            <IconButton onClick={() => onUndoSelectionChanges()}>
-                                                <UndoIcon />
-                                            </IconButton>
-                                        </Tooltip>
-                                        <Button
-                                            variant={"contained"}
-                                            startIcon={<CloudUploadIcon sx={{ color: "#fff" }} />}
-                                            onClick={() => onUpdateConfig()}
-                                        >
-                                            <Typography color={"#fff"}>Oppdater</Typography>
-                                        </Button>
-                                    </Box>
+                                        size={26}
+                                        thickness={6}
+                                    />
                                 ) : (
-                                    <Tooltip title={"Lagret"}>
-                                        <CloudDoneIcon color={"disabled"} />
+                                    <>
+                                        {changed ? (
+                                            <Box
+                                                sx={{
+                                                    display: {
+                                                        xs: "none",
+                                                        sm: "flex",
+                                                    },
+                                                    alignItems: "center",
+                                                    gap: 1,
+                                                }}
+                                            >
+                                                <Tooltip title={"Angre"}>
+                                                    <IconButton onClick={() => onUndoSelectionChanges()}>
+                                                        <UndoIcon />
+                                                    </IconButton>
+                                                </Tooltip>
+                                                <Button
+                                                    variant={"contained"}
+                                                    startIcon={<CloudUploadIcon sx={{ color: "#fff" }} />}
+                                                    onClick={() => onUpdateConfig()}
+                                                >
+                                                    <Typography color={"#fff"}>Oppdater</Typography>
+                                                </Button>
+                                            </Box>
+                                        ) : (
+                                            <Tooltip title={"Lagret"}>
+                                                <CloudDoneIcon color={"disabled"} />
+                                            </Tooltip>
+                                        )}
+                                        <Box
+                                            sx={{
+                                                display: "flex",
+                                                alignItems: "center",
+                                            }}
+                                        >
+                                            <Tooltip title={"Agenda"}>
+                                                <IconButton onClick={() => onAgendaOpen()} disabled={!agendaEnabled}>
+                                                    <FormatListBulletedRoundedIcon />
+                                                </IconButton>
+                                            </Tooltip>
+                                            <Tooltip title={"Innstillinger"}>
+                                                <IconButton onClick={() => onSettingsOpen()}>
+                                                    <SettingsRoundedIcon />
+                                                </IconButton>
+                                            </Tooltip>
+                                        </Box>
+                                    </>
+                                )}
+                                {user.name && (
+                                    <Tooltip title={user.name}>
+                                        <Avatar
+                                            sx={{
+                                                width: 32,
+                                                height: 32,
+                                                fontSize: 18,
+                                                backgroundColor: hexColorHash(user.name),
+                                            }}
+                                        >
+                                            {user.name[0]}
+                                        </Avatar>
                                     </Tooltip>
                                 )}
-                                <Box
-                                    sx={{
-                                        display: "flex",
-                                        alignItems: "center",
-                                    }}
-                                >
-                                    <Tooltip title={"Agenda"}>
-                                        <IconButton onClick={() => onAgendaOpen()} disabled={!agendaEnabled}>
-                                            <FormatListBulletedRoundedIcon />
-                                        </IconButton>
-                                    </Tooltip>
-                                    <Tooltip title={"Innstillinger"}>
-                                        <IconButton onClick={() => onSettingsOpen()}>
-                                            <SettingsRoundedIcon />
-                                        </IconButton>
-                                    </Tooltip>
-                                </Box>
-                            </>
+                                <Tooltip title={"Logg ut"}>
+                                    <IconButton href={"/api/auth/logout"}>
+                                        <LogoutRoundedIcon />
+                                    </IconButton>
+                                </Tooltip>
+                            </Box>
+                        ) : (
+                            <Box>
+                                <Tooltip title={"Logg inn"}>
+                                    <IconButton color={"primary"} href={"/api/auth/login"}>
+                                        <LoginIcon />
+                                    </IconButton>
+                                </Tooltip>
+                            </Box>
                         )}
-                        {user.name && (
-                            <Tooltip title={user.name}>
-                                <Avatar
-                                    sx={{
-                                        width: 32,
-                                        height: 32,
-                                        fontSize: 18,
-                                        backgroundColor: hexColorHash(user.name),
-                                    }}
-                                >
-                                    {user.name[0]}
-                                </Avatar>
-                            </Tooltip>
-                        )}
-                        <Tooltip title={"Logg ut"}>
-                            <IconButton href={"/api/auth/logout"}>
-                                <LogoutRoundedIcon />
-                            </IconButton>
-                        </Tooltip>
                     </Box>
-                ) : (
-                    <Box>
-                        <Tooltip title={"Logg inn"}>
-                            <IconButton color={"primary"} href={"/api/auth/login"}>
-                                <LoginIcon />
-                            </IconButton>
-                        </Tooltip>
-                    </Box>
-                )}
+                </Box>
             </Box>
         </Box>
     );

--- a/components/MobileConfigUpdateBar.tsx
+++ b/components/MobileConfigUpdateBar.tsx
@@ -4,45 +4,60 @@ import CloudUploadIcon from "@mui/icons-material/CloudUpload";
 import React from "react";
 
 export default function MobileConfigUpdateBar({
+    visible,
     isLoadingConfig,
     onUpdateConfig,
     onUndoSelectionChanges,
 }: {
+    visible: boolean;
     isLoadingConfig: boolean;
     onUpdateConfig: () => void;
     onUndoSelectionChanges: () => void;
 }) {
+    if (!visible) {
+        return <></>;
+    }
+
     return (
         <Box
             sx={{
-                gap: 1,
-                display: { xs: "flex", sm: "none" },
-                alignItems: "center",
-                justifyContent: "center",
+                position: "fixed",
+                padding: "1.5rem",
+                bottom: 0,
+                right: 0,
             }}
         >
-            {isLoadingConfig ? (
-                <Fab color={"primary"} size="small">
-                    <CircularProgress sx={{ color: "white" }} size={26} thickness={6} />
-                </Fab>
-            ) : (
-                <>
-                    <Fab size="small" onClick={() => onUndoSelectionChanges()}>
-                        <UndoIcon
-                            sx={{
-                                fontSize: 18,
-                                '[data-mui-color-scheme="dark"] &': {
-                                    color: "#111",
-                                },
-                            }}
-                        />
+            <Box
+                sx={{
+                    gap: 1,
+                    display: { xs: "flex", sm: "none" },
+                    alignItems: "center",
+                    justifyContent: "center",
+                }}
+            >
+                {isLoadingConfig ? (
+                    <Fab color={"primary"} size="small">
+                        <CircularProgress sx={{ color: "white" }} size={26} thickness={6} />
                     </Fab>
-                    <Fab color={"primary"} variant="extended" onClick={() => onUpdateConfig()}>
-                        <CloudUploadIcon sx={{ mr: 1, color: "#fff" }} />
-                        <Typography color={"#fff"}>Oppdater</Typography>
-                    </Fab>
-                </>
-            )}
+                ) : (
+                    <>
+                        <Fab size="small" onClick={() => onUndoSelectionChanges()}>
+                            <UndoIcon
+                                sx={{
+                                    fontSize: 18,
+                                    '[data-mui-color-scheme="dark"] &': {
+                                        color: "#111",
+                                    },
+                                }}
+                            />
+                        </Fab>
+                        <Fab color={"primary"} variant="extended" onClick={() => onUpdateConfig()}>
+                            <CloudUploadIcon sx={{ mr: 1, color: "#fff" }} />
+                            <Typography color={"#fff"}>Oppdater</Typography>
+                        </Fab>
+                    </>
+                )}
+            </Box>
         </Box>
     );
 }

--- a/components/Schedule.tsx
+++ b/components/Schedule.tsx
@@ -43,64 +43,69 @@ const Schedule = ({
     }
 
     return (
-        <Stack direction={"column"}>
-            <Stack direction={"row"} margin={"auto"} spacing={2} px={1}>
-                {schedule.days.map((day) => (
-                    <Box key={day.date} width={180}>
-                        <Box py={2} sx={{ opacity: isDayPassed(day.date) ? 1 : 0.5 }}>
-                            <Typography variant="h6" component="div">
-                                {day.dayName}{" "}
-                                {isToday(day.date) && (
-                                    <Chip
-                                        size={"small"}
-                                        sx={{ backgroundColor: theme.palette.primary.dark, color: "#fff" }}
-                                        label="I dag"
-                                    />
-                                )}
-                            </Typography>
-                            <Typography
-                                variant="h6"
-                                component="div"
-                                style={{
-                                    color: theme.palette.grey[600],
-                                    fontSize: 15,
-                                }}
-                            >
-                                {day.date}
-                            </Typography>
+        <Box sx={{ flexGrow: 1, overflow: "auto" }}>
+            <Stack direction={"column"}>
+                <Stack direction={"row"} margin={"auto"} spacing={2} px={1}>
+                    {schedule.days.map((day) => (
+                        <Box key={day.date} width={180}>
+                            <Box py={2} sx={{ opacity: isDayPassed(day.date) ? 1 : 0.5 }}>
+                                <Typography variant="h6" component="div">
+                                    {day.dayName}{" "}
+                                    {isToday(day.date) && (
+                                        <Chip
+                                            size={"small"}
+                                            sx={{ backgroundColor: theme.palette.primary.dark, color: "#fff" }}
+                                            label="I dag"
+                                        />
+                                    )}
+                                </Typography>
+                                <Typography
+                                    variant="h6"
+                                    component="div"
+                                    style={{
+                                        color: theme.palette.grey[600],
+                                        fontSize: 15,
+                                    }}
+                                >
+                                    {day.date}
+                                </Typography>
+                            </Box>
+                            {day.classes.length > 0 ? (
+                                day.classes.map((_class) => (
+                                    <Box key={_class.id} mb={1}>
+                                        <ClassCard
+                                            _class={_class}
+                                            popularity={
+                                                classPopularityIndex[sitClassRecurrentId(_class)] ??
+                                                ClassPopularity.Unknown
+                                            }
+                                            configUsers={
+                                                allConfigsIndex
+                                                    ? allConfigsIndex[sitClassRecurrentId(_class)] ?? []
+                                                    : []
+                                            }
+                                            userSessions={userSessionsIndex ? userSessionsIndex[_class.id] ?? [] : []}
+                                            selectable={selectable}
+                                            selected={
+                                                selectedClassIds != null &&
+                                                selectedClassIds.includes(sitClassRecurrentId(_class))
+                                            }
+                                            onSelectedChanged={(s) => onSelectedChanged(sitClassRecurrentId(_class), s)}
+                                            onInfo={() => onInfo(_class)}
+                                            // onSettings={() =>
+                                            //     setSettingsClass(_class)
+                                            // }
+                                        />
+                                    </Box>
+                                ))
+                            ) : (
+                                <p>Ingen gruppetimer</p>
+                            )}
                         </Box>
-                        {day.classes.length > 0 ? (
-                            day.classes.map((_class) => (
-                                <Box key={_class.id} mb={1}>
-                                    <ClassCard
-                                        _class={_class}
-                                        popularity={
-                                            classPopularityIndex[sitClassRecurrentId(_class)] ?? ClassPopularity.Unknown
-                                        }
-                                        configUsers={
-                                            allConfigsIndex ? allConfigsIndex[sitClassRecurrentId(_class)] ?? [] : []
-                                        }
-                                        userSessions={userSessionsIndex ? userSessionsIndex[_class.id] ?? [] : []}
-                                        selectable={selectable}
-                                        selected={
-                                            selectedClassIds != null &&
-                                            selectedClassIds.includes(sitClassRecurrentId(_class))
-                                        }
-                                        onSelectedChanged={(s) => onSelectedChanged(sitClassRecurrentId(_class), s)}
-                                        onInfo={() => onInfo(_class)}
-                                        // onSettings={() =>
-                                        //     setSettingsClass(_class)
-                                        // }
-                                    />
-                                </Box>
-                            ))
-                        ) : (
-                            <p>Ingen gruppetimer</p>
-                        )}
-                    </Box>
-                ))}
+                    ))}
+                </Stack>
             </Stack>
-        </Stack>
+        </Box>
     );
 };
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -261,18 +261,16 @@ const Index: NextPage<{
                     />
                     <Divider orientation="horizontal" />
                 </Box>
-                <Box sx={{ flexGrow: 1, overflow: "auto" }}>
-                    <ScheduleMemo
-                        schedule={currentSchedule}
-                        classPopularityIndex={classPopularityIndex}
-                        selectable={userConfig != undefined && !userConfigLoading && !userConfigError}
-                        selectedClassIds={selectedClassIds}
-                        allConfigsIndex={allConfigsIndex ?? null}
-                        userSessionsIndex={userSessionsIndex ?? null}
-                        onSelectedChanged={onSelectedChanged}
-                        onInfo={setClassInfoClass}
-                    />
-                </Box>
+                <ScheduleMemo
+                    schedule={currentSchedule}
+                    classPopularityIndex={classPopularityIndex}
+                    selectable={userConfig != undefined && !userConfigLoading && !userConfigError}
+                    selectedClassIds={selectedClassIds}
+                    allConfigsIndex={allConfigsIndex ?? null}
+                    userSessionsIndex={userSessionsIndex ?? null}
+                    onSelectedChanged={onSelectedChanged}
+                    onInfo={setClassInfoClass}
+                />
                 {selectionChanged && (
                     <Box
                         sx={{

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -242,20 +242,16 @@ const Index: NextPage<{
             </Head>
             <Stack sx={{ height: "100%", overflow: "hidden" }}>
                 <Box sx={{ flexShrink: 0 }}>
-                    <Box display={"flex"} justifyContent={"center"}>
-                        <Box width={1388}>
-                            <AppBar
-                                changed={selectionChanged}
-                                agendaEnabled={userConfig?.classes != undefined && userConfig.classes.length > 0}
-                                isLoadingConfig={userConfig == null || userConfigLoading}
-                                isConfigError={userConfigError}
-                                onUpdateConfig={() => updateConfigFromSelection()}
-                                onUndoSelectionChanges={() => setSelectedClassIds(originalSelectedClassIds)}
-                                onSettingsOpen={() => setIsSettingsOpen(true)}
-                                onAgendaOpen={() => setIsAgendaOpen(true)}
-                            />
-                        </Box>
-                    </Box>
+                    <AppBar
+                        changed={selectionChanged}
+                        agendaEnabled={userConfig?.classes != undefined && userConfig.classes.length > 0}
+                        isLoadingConfig={userConfig == null || userConfigLoading}
+                        isConfigError={userConfigError}
+                        onUpdateConfig={() => updateConfigFromSelection()}
+                        onUndoSelectionChanges={() => setSelectedClassIds(originalSelectedClassIds)}
+                        onSettingsOpen={() => setIsSettingsOpen(true)}
+                        onAgendaOpen={() => setIsAgendaOpen(true)}
+                    />
                     <WeekNavigator
                         weekNumber={DateTime.fromISO(currentSchedule.days[0]!.date).weekNumber}
                         weekOffset={weekOffset}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -271,22 +271,12 @@ const Index: NextPage<{
                     onSelectedChanged={onSelectedChanged}
                     onInfo={setClassInfoClass}
                 />
-                {selectionChanged && (
-                    <Box
-                        sx={{
-                            position: "fixed",
-                            padding: "1.5rem",
-                            bottom: 0,
-                            right: 0,
-                        }}
-                    >
-                        <MobileConfigUpdateBar
-                            isLoadingConfig={userConfigLoading}
-                            onUpdateConfig={() => updateConfigFromSelection()}
-                            onUndoSelectionChanges={() => setSelectedClassIds(originalSelectedClassIds)}
-                        />
-                    </Box>
-                )}
+                <MobileConfigUpdateBar
+                    visible={selectionChanged}
+                    isLoadingConfig={userConfigLoading}
+                    onUpdateConfig={() => updateConfigFromSelection()}
+                    onUndoSelectionChanges={() => setSelectedClassIds(originalSelectedClassIds)}
+                />
             </Stack>
             <Modal open={classInfoClass != null} onClose={() => setClassInfoClass(null)}>
                 <>


### PR DESCRIPTION
With this PR, I do some cleanup in terms of moving logic that is only used (or wrapped around) a component into said component. This is to hide that components specific display and styling from the index file. No logic changes here, only moving wrapping elements (thus resulting in huge diffs, but in reality it is mostly indenting) It is therefore easiest to see the changes by going commit by commit. 

Again, a small stepping stone into generalising `sit-rezervo-confgen`